### PR TITLE
Added event name on event class

### DIFF
--- a/src/Smalot/Github/Webhook/Event/CommitCommentEvent.php
+++ b/src/Smalot/Github/Webhook/Event/CommitCommentEvent.php
@@ -12,6 +12,9 @@ use Smalot\Github\Webhook\Model\CommitCommentModel;
  */
 class CommitCommentEvent extends EventBase
 {
+
+    const NAME = 'commit_comment';
+
     /**
      * @return string
      */

--- a/src/Smalot/Github/Webhook/Event/CreateEvent.php
+++ b/src/Smalot/Github/Webhook/Event/CreateEvent.php
@@ -14,6 +14,9 @@ use Smalot\Github\Webhook\Model\CreateModel;
  */
 class CreateEvent extends EventBase
 {
+
+    const NAME = 'create';
+
     /**
      * @return string
      */

--- a/src/Smalot/Github/Webhook/Event/DeleteEvent.php
+++ b/src/Smalot/Github/Webhook/Event/DeleteEvent.php
@@ -12,6 +12,9 @@ use Smalot\Github\Webhook\Model\DeleteModel;
  */
 class DeleteEvent extends EventBase
 {
+
+    const NAME = 'delete';
+
     /**
      * @return string
      */

--- a/src/Smalot/Github/Webhook/Event/DeploymentEvent.php
+++ b/src/Smalot/Github/Webhook/Event/DeploymentEvent.php
@@ -14,6 +14,9 @@ use Smalot\Github\Webhook\Model\DeploymentModel;
  */
 class DeploymentEvent extends EventBase
 {
+
+    const NAME = 'deployment';
+
     /**
      * @return string
      */

--- a/src/Smalot/Github/Webhook/Event/DeploymentStatusEvent.php
+++ b/src/Smalot/Github/Webhook/Event/DeploymentStatusEvent.php
@@ -14,6 +14,9 @@ use Smalot\Github\Webhook\Model\DeploymentStatusModel;
  */
 class DeploymentStatusEvent extends EventBase
 {
+
+    const NAME = 'deployment_status';
+
     /**
      * @return string
      */

--- a/src/Smalot/Github/Webhook/Event/DownloadEvent.php
+++ b/src/Smalot/Github/Webhook/Event/DownloadEvent.php
@@ -14,6 +14,9 @@ use Smalot\Github\Webhook\Model\DownloadModel;
  */
 class DownloadEvent extends EventBase
 {
+
+    const NAME = 'download';
+
     /**
      * @return string
      */

--- a/src/Smalot/Github/Webhook/Event/FollowEvent.php
+++ b/src/Smalot/Github/Webhook/Event/FollowEvent.php
@@ -14,6 +14,9 @@ use Smalot\Github\Webhook\Model\FollowModel;
  */
 class FollowEvent extends EventBase
 {
+
+    const NAME = 'follow';
+
     /**
      * @return string
      */

--- a/src/Smalot/Github/Webhook/Event/ForkApplyEvent.php
+++ b/src/Smalot/Github/Webhook/Event/ForkApplyEvent.php
@@ -14,6 +14,9 @@ use Smalot\Github\Webhook\Model\ForkApplyModel;
  */
 class ForkApplyEvent extends EventBase
 {
+
+    const NAME = 'fork_apply';
+
     /**
      * @return string
      */

--- a/src/Smalot/Github/Webhook/Event/ForkEvent.php
+++ b/src/Smalot/Github/Webhook/Event/ForkEvent.php
@@ -12,6 +12,9 @@ use Smalot\Github\Webhook\Model\ForkModel;
  */
 class ForkEvent extends EventBase
 {
+
+    const NAME = 'fork';
+
     /**
      * @return string
      */

--- a/src/Smalot/Github/Webhook/Event/GistEvent.php
+++ b/src/Smalot/Github/Webhook/Event/GistEvent.php
@@ -14,6 +14,9 @@ use Smalot\Github\Webhook\Model\GistModel;
  */
 class GistEvent extends EventBase
 {
+
+    const NAME = 'gist';
+
     /**
      * @return string
      */

--- a/src/Smalot/Github/Webhook/Event/GollumEvent.php
+++ b/src/Smalot/Github/Webhook/Event/GollumEvent.php
@@ -12,6 +12,9 @@ use Smalot\Github\Webhook\Model\GollumModel;
  */
 class GollumEvent extends EventBase
 {
+
+    const NAME = 'gollum';
+
     /**
      * @return string
      */

--- a/src/Smalot/Github/Webhook/Event/IssueCommentEvent.php
+++ b/src/Smalot/Github/Webhook/Event/IssueCommentEvent.php
@@ -12,6 +12,9 @@ use Smalot\Github\Webhook\Model\IssueCommentModel;
  */
 class IssueCommentEvent extends EventBase
 {
+
+    const NAME = 'issue_comment';
+
     /**
      * @return string
      */

--- a/src/Smalot/Github/Webhook/Event/IssuesEvent.php
+++ b/src/Smalot/Github/Webhook/Event/IssuesEvent.php
@@ -12,6 +12,9 @@ use Smalot\Github\Webhook\Model\IssuesModel;
  */
 class IssuesEvent extends EventBase
 {
+
+    const NAME = 'issues';
+
     /**
      * @return string
      */

--- a/src/Smalot/Github/Webhook/Event/MemberEvent.php
+++ b/src/Smalot/Github/Webhook/Event/MemberEvent.php
@@ -12,6 +12,9 @@ use Smalot\Github\Webhook\Model\MemberModel;
  */
 class MemberEvent extends EventBase
 {
+
+    const NAME = 'member';
+
     /**
      * @return string
      */

--- a/src/Smalot/Github/Webhook/Event/MembershipEvent.php
+++ b/src/Smalot/Github/Webhook/Event/MembershipEvent.php
@@ -14,6 +14,9 @@ use Smalot\Github\Webhook\Model\MembershipModel;
  */
 class MembershipEvent extends EventBase
 {
+
+    const NAME = 'membership';
+
     /**
      * @return string
      */

--- a/src/Smalot/Github/Webhook/Event/PageBuildEvent.php
+++ b/src/Smalot/Github/Webhook/Event/PageBuildEvent.php
@@ -16,6 +16,9 @@ use Smalot\Github\Webhook\Model\PageBuildModel;
  */
 class PageBuildEvent extends EventBase
 {
+
+    const NAME = 'page_build';
+
     /**
      * @return string
      */

--- a/src/Smalot/Github/Webhook/Event/PingEvent.php
+++ b/src/Smalot/Github/Webhook/Event/PingEvent.php
@@ -14,6 +14,9 @@ use Smalot\Github\Webhook\Model\PingModel;
  */
 class PingEvent extends EventBase
 {
+
+    const NAME = 'ping';
+
     /**
      * @return string
      */

--- a/src/Smalot/Github/Webhook/Event/PublicEvent.php
+++ b/src/Smalot/Github/Webhook/Event/PublicEvent.php
@@ -12,6 +12,9 @@ use Smalot\Github\Webhook\Model\PublicModel;
  */
 class PublicEvent extends EventBase
 {
+
+    const NAME = 'public';
+
     /**
      * @return string
      */

--- a/src/Smalot/Github/Webhook/Event/PullRequestEvent.php
+++ b/src/Smalot/Github/Webhook/Event/PullRequestEvent.php
@@ -13,6 +13,9 @@ use Smalot\Github\Webhook\Model\PullRequestModel;
  */
 class PullRequestEvent extends EventBase
 {
+
+    const NAME = 'pull_request';
+
     /**
      * @return string
      */

--- a/src/Smalot/Github/Webhook/Event/PullRequestReviewCommentEvent.php
+++ b/src/Smalot/Github/Webhook/Event/PullRequestReviewCommentEvent.php
@@ -12,6 +12,9 @@ use Smalot\Github\Webhook\Model\PullRequestReviewCommentModel;
  */
 class PullRequestReviewCommentEvent extends EventBase
 {
+
+    const NAME = 'pull_request_review_comment';
+
     /**
      * @return string
      */

--- a/src/Smalot/Github/Webhook/Event/PushEvent.php
+++ b/src/Smalot/Github/Webhook/Event/PushEvent.php
@@ -13,6 +13,9 @@ use Smalot\Github\Webhook\Model\PushModel;
  */
 class PushEvent extends EventBase
 {
+
+    const NAME = 'push';
+
     /**
      * @return string
      */

--- a/src/Smalot/Github/Webhook/Event/ReleaseEvent.php
+++ b/src/Smalot/Github/Webhook/Event/ReleaseEvent.php
@@ -12,6 +12,9 @@ use Smalot\Github\Webhook\Model\ReleaseModel;
  */
 class ReleaseEvent extends EventBase
 {
+
+    const NAME = 'release';
+
     /**
      * @return string
      */

--- a/src/Smalot/Github/Webhook/Event/RepositoryEvent.php
+++ b/src/Smalot/Github/Webhook/Event/RepositoryEvent.php
@@ -14,6 +14,9 @@ use Smalot\Github\Webhook\Model\RepositoryModel;
  */
 class RepositoryEvent extends EventBase
 {
+
+    const NAME = 'repository';
+
     /**
      * @return string
      */

--- a/src/Smalot/Github/Webhook/Event/StatusEvent.php
+++ b/src/Smalot/Github/Webhook/Event/StatusEvent.php
@@ -14,6 +14,9 @@ use Smalot\Github\Webhook\Model\StatusModel;
  */
 class StatusEvent extends EventBase
 {
+
+    const NAME = 'status';
+
     /**
      * @return string
      */

--- a/src/Smalot/Github/Webhook/Event/TeamAddEvent.php
+++ b/src/Smalot/Github/Webhook/Event/TeamAddEvent.php
@@ -14,6 +14,9 @@ use Smalot\Github\Webhook\Model\TeamAddModel;
  */
 class TeamAddEvent extends EventBase
 {
+
+    const NAME = 'team_add';
+
     /**
      * @return string
      */

--- a/src/Smalot/Github/Webhook/Event/WatchEvent.php
+++ b/src/Smalot/Github/Webhook/Event/WatchEvent.php
@@ -14,6 +14,9 @@ use Smalot\Github\Webhook\Model\WatchModel;
  */
 class WatchEvent extends EventBase
 {
+
+    const NAME = 'watch';
+
     /**
      * @return string
      */


### PR DESCRIPTION
Added event name on event class, so it much easier to use it in fx

``` php
public static function getSubscribedEvents()
{
        return array(
            CommitCommentEvent::NAME => 'onCommit',
        );
}
```

Instead of guessing the name
